### PR TITLE
Added UTC timestamp to message, new index

### DIFF
--- a/crash-app.go
+++ b/crash-app.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"time"
 
 	"encoding/json"
 	"io/ioutil"
@@ -40,8 +41,10 @@ func sendLogs(filename string) error {
 	failedTask := getFailedTask(log)
 
 	// Format data for POST request and send to ElasticSearch.
-	url := "https://k2crashreporter.kubeme.io/k2crashreporter/k2crashes"
-	body := map[string]string{"k2_log": log, "failed_task": failedTask}
+	url := "https://krakencrashreporter.kubeme.io/krakencrashreporter/krakencrashes"
+	t := time.Now().UTC()
+	ts := t.Format("2006-01-02T15:04:05.000Z")
+	body := map[string]string{"k2_log": log, "failed_task": failedTask, "date": ts}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		err = fmt.Errorf("Error preparing data in json format for POST request: %v", err)


### PR DESCRIPTION
I added a UTC datetime to the message, which helps query in kibana.
The new elasticsearch index is: "krakencrashreporter/krakencrashes"
Note: I also added a new CNAME in the prod cluster, if you don't want to use it we can use the old one which is "k2crashreporter.kubeme.io"
The new and old CNAMES are defined and I have an ingress for both of them pointing to crashbackend in the production cluster to support the existing crashapp.
